### PR TITLE
Avoid upstream GitHub cross-reference notifications in digest issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Browse all historical digests in a clean, dark-themed interface — no login req
 
 Subscribe in any RSS reader (Feedly, Reeder, NewsBlur, etc.) to receive new digests automatically. The feed includes the latest 30 reports across all report types, updated daily alongside `manifest.json`.
 
+GitHub Issues are posted with upstream GitHub issue/PR links defanged to avoid creating mention/backreference noise in tracked project repositories. The committed Markdown reports and Web UI keep the normal source links.
+
 ## MCP Server
 
 **`https://big-model-radar-mcp.<your-subdomain>.workers.dev`**

--- a/README.zh.md
+++ b/README.zh.md
@@ -16,6 +16,8 @@
 
 在任意 RSS 阅读器（Feedly、Reeder、NewsBlur 等）中订阅，每日自动推送新简报。Feed 包含最新 30 条报告（覆盖所有报告类型），与 `manifest.json` 同步更新。
 
+发布到 GitHub Issues 的正文会对上游 GitHub Issue/PR 链接做 defang 处理，避免在被追踪项目仓库中产生 mention/backreference 噪音。提交到仓库的 Markdown 报告和 Web UI 仍保留正常源链接。
+
 ## MCP Server
 
 **`https://big-model-radar-mcp.<your-subdomain>.workers.dev`**

--- a/src/github.ts
+++ b/src/github.ts
@@ -187,9 +187,20 @@ const TRUNCATION_NOTICE = "\n\n---\n> ⚠️ 内容超过 GitHub Issue 上限，
 function defangGitHubNotifications(body: string): string {
   return body
     .replace(
-      /https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/(issues|pull)\/(\d+)/g,
-      (_match, owner: string, repo: string, type: string, number: string) =>
-        `github[.]com/${owner}/${repo}/${type}/${number}`,
+      /https?:\/\/(?:www\.)?github\.com\/[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\/(?:issues|pull)\/\d+(?:[/?#][^\s`<>"']*)?/g,
+      (match: string) => {
+        const trailingPunctuationMatch = match.match(/[),.!?:;]+$/);
+        const trailingPunctuation = trailingPunctuationMatch?.[0] ?? "";
+        const urlWithoutTrailingPunctuation = trailingPunctuation
+          ? match.slice(0, -trailingPunctuation.length)
+          : match;
+        return (
+          urlWithoutTrailingPunctuation.replace(
+            /^https?:\/\/(?:www\.)?github\.com/,
+            "github[.]com",
+          ) + trailingPunctuation
+        );
+      },
     )
     .replace(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#(\d+)\b/g, "`$1#$2`")
     .replace(/(^|[^\w`])@([A-Za-z0-9-]{1,39})\b/g, "$1@\u200B$2");

--- a/src/github.ts
+++ b/src/github.ts
@@ -184,8 +184,20 @@ export async function fetchSkillsData(repo: string): Promise<{ prs: GitHubItem[]
 const GITHUB_ISSUE_BODY_LIMIT = 65536;
 const TRUNCATION_NOTICE = "\n\n---\n> ⚠️ 内容超过 GitHub Issue 上限，完整报告见提交的 Markdown 文件。";
 
+function defangGitHubNotifications(body: string): string {
+  return body
+    .replace(
+      /https?:\/\/(?:www\.)?github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+)\/(issues|pull)\/(\d+)/g,
+      (_match, owner: string, repo: string, type: string, number: string) =>
+        `github[.]com/${owner}/${repo}/${type}/${number}`,
+    )
+    .replace(/\b([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#(\d+)\b/g, "`$1#$2`")
+    .replace(/(^|[^\w`])@([A-Za-z0-9-]{1,39})\b/g, "$1@\u200B$2");
+}
+
 export async function createGitHubIssue(title: string, body: string, label: string): Promise<string> {
   const digestRepo = process.env["DIGEST_REPO"] ?? "";
+  body = defangGitHubNotifications(body);
   if (body.length > GITHUB_ISSUE_BODY_LIMIT) {
     body = body.slice(0, GITHUB_ISSUE_BODY_LIMIT - TRUNCATION_NOTICE.length) + TRUNCATION_NOTICE;
   }


### PR DESCRIPTION
## Summary

This prevents Big Model Radar's generated GitHub Issues from creating cross-repository backreference noise in tracked upstream projects.

The committed Markdown reports and Web UI can continue to use normal source links, but the body sent to createGitHubIssue now defangs GitHub issue/PR URLs, shorthand owner/repo#123 references, and @user mentions before posting.

## Why

Digest issues currently include direct links to upstream issues and pull requests. GitHub turns those links into timeline events such as "mentioned this pull request" in the upstream repositories, which can be noisy for projects being monitored.

## Validation

- Checked the branch diff against gsscsd/main; it only changes README.md, README.zh.md, and src/github.ts.
- Verified the defanging behavior locally with an example: https://github.com/moltis-org/moltis/pull/869 becomes github[.]com/moltis-org/moltis/pull/869, and moltis-org/moltis#869 is rendered as inline code.
- Ran git diff --check.

Full project typecheck was not run because this checkout does not have local Node dependencies installed.